### PR TITLE
feat: `screenshot-bot.config.toml` new configs `screenshotImageAttrs` & `failedTestsReportDescription`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ newScreenshotMark = '.*==new==.*'
 
 # array of RegExp strings to match branch names which should be skipped by bot
 branchesIgnore = []
+
+# array of attributes (key="value") for html-tag <img /> (screenshots)
+screenshotImageAttrs = ['height="300px"']
+
+# Text which is placed at the beginning of section "Failed tests"
+failedTestsReportDescription = ''
 ```
 
 ## What bot can do? :bulb:

--- a/src/classes/bot.ts
+++ b/src/classes/bot.ts
@@ -368,6 +368,12 @@ export class ScreenshotBot<T extends EmitterWebhookEventName> extends Bot<T> {
             .catch(() => DEFAULT_BOT_CONFIGS);
     }
 
+    async getBotConfigs(
+        branch: string = DEFAULT_MAIN_BRANCH
+    ): Promise<Required<IBotConfigs>> {
+        return this.botConfigs || this.loadBotConfigs(branch);
+    }
+
     async getPrevBotReportComment(prNumber: number) {
         const prComments = await this.getCommentsByIssueId(prNumber);
 

--- a/src/constants/bot-configs.constants.ts
+++ b/src/constants/bot-configs.constants.ts
@@ -10,4 +10,6 @@ export const DEFAULT_BOT_CONFIGS: Required<IBotConfigs> = {
     ],
     newScreenshotMark: '.*==new==.*',
     branchesIgnore: [],
+    screenshotImageAttrs: ['height="300"'],
+    failedTestsReportDescription: '',
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,12 +73,13 @@ const EVENTS_CALLBACKS = {
             workflowRunId
         );
 
+        const botConfigs = await bot.getBotConfigs();
         const reportText =
             failedTestsImages.length || newTestsImages.length
                 ? getFailureReport(
                       zip(failedTestsImages, failedTestsImagesUrls),
                       zip(newTestsImages, newTestsImagesUrls),
-                      { commitSha }
+                      { commitSha, botConfigs }
                   )
                 : BotReportMessage.FailedWorkflowNoScreenshots;
 

--- a/src/types/bot-configs.types.ts
+++ b/src/types/bot-configs.types.ts
@@ -24,4 +24,16 @@ export interface IBotConfigs {
      * @example ["^release/.*"]
      */
     branchesIgnore: string[];
+    /**
+     * array of attributes (key="value") for html-tag <img /> (screenshots)
+     * ___
+     * @example ['width="200px"', 'height="300px"']
+     */
+    screenshotImageAttrs: string[];
+    /**
+     * Text which is placed at the beginning of section "Failed tests"
+     * ___
+     * @example **After <= Diff => Before**
+     */
+    failedTestsReportDescription: string;
 }

--- a/src/utils/tests-report.utils.ts
+++ b/src/utils/tests-report.utils.ts
@@ -1,34 +1,63 @@
 import type { IZipEntry } from 'adm-zip';
+import type { IBotConfigs } from '../types';
 
 const createCollapsibleScreenshot = (
     [{ entryName }, link]: [IZipEntry, string],
-    initialOpen: boolean = true
+    initialOpen: boolean = true,
+    imageAttrs: string[] = []
 ): string => `
 <details ${initialOpen ? 'open' : ''}>
     <summary><strong>${entryName}</strong></summary>
-    <img src="${link}" height="300"/>
+    <img src="${link}" ${imageAttrs.join(' ')}/>
 </details>
 `;
 
 const createReport = (
     header: string,
     screenshotsInfo: Array<[IZipEntry, string]>,
-    allOpen: boolean = true
+    {
+        allOpen = true,
+        description = '',
+        imageAttrs = [],
+    }: { allOpen?: boolean; description?: string; imageAttrs?: string[] }
 ): string => `
 <h1>${header}</h1>
+
+${description}
+
 ${screenshotsInfo
-    .map((screenshot) => createCollapsibleScreenshot(screenshot, allOpen))
+    .map((screenshot) =>
+        createCollapsibleScreenshot(screenshot, allOpen, imageAttrs)
+    )
     .join('')}
 `;
 
 export const getFailureReport = (
     failedTests: Array<[IZipEntry, string]>,
     newTests: Array<[IZipEntry, string]>,
-    { commitSha }: { commitSha: string }
+    {
+        commitSha,
+        botConfigs,
+    }: { botConfigs: Required<IBotConfigs>; commitSha: string }
 ): string => `
-${failedTests.length ? createReport('Failed tests :x:', failedTests, true) : ''}
+${
+    failedTests.length
+        ? createReport('Failed tests :x:', failedTests, {
+              allOpen: true,
+              description: botConfigs.failedTestsReportDescription,
+              imageAttrs: botConfigs.screenshotImageAttrs,
+          })
+        : ''
+}
 <br />
-${newTests.length ? createReport('New tests :test_tube:', newTests, false) : ''}
+${
+    newTests.length
+        ? createReport('New tests :test_tube:', newTests, {
+              allOpen: false,
+              imageAttrs: botConfigs.screenshotImageAttrs,
+          })
+        : ''
+}
 
 <sub>(updated for commit ${commitSha})</sub>
 `;


### PR DESCRIPTION
New configs
```yaml
# array of attributes (key="value") for html-tag <img /> (screenshots)
screenshotImageAttrs = ['height="300px"']
# Text which is placed at the beginning of section "Failed tests"
failedTestsReportDescription = '**After <= Diff => Before**'
```

Closes #26
Closes #27